### PR TITLE
Fix grid window unicode input and Glk input array (un)registration.

### DIFF
--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -459,8 +459,9 @@ struct window_textgrid_s
 
     /* for line input */
     void *inbuf;	/* unsigned char* for latin1, glui32* for unicode */
+    int inunicode;
     int inorgx, inorgy;
-    int inmax;
+    int inoriglen, inmax;
     int incurs, inlen;
     attr_t origattr;
     gidispatch_rock_t inarrayrock;
@@ -513,6 +514,7 @@ struct window_textbuffer_s
 
     /* for line input */
     void *inbuf;	/* unsigned char* for latin1, glui32* for unicode */
+    int inunicode;
     int inmax;
     long infence;
     long incurs;


### PR DESCRIPTION
Fixes a bug in Unicode input for grid windows that was discovered with
the inputeventtest.ulx unit test (see GitHub glk-dev project). This bug
caused fatal errors in both git and glulxe interpreters when trying to
read input from the status window and the window was less than 80
characters wide.

Caused by code registering the input array with the Glk dispatch
mechanism using a different length than the array’s original length.
The array length was modified when truncating input buffer for a grid
window as, per spec, input in grid windows is restricted to a single
line.